### PR TITLE
Defer call to FcPatternDestroy(). (fixes Issue #16)

### DIFF
--- a/main.c
+++ b/main.c
@@ -1038,12 +1038,13 @@ int main(int argc, char* argv[]) {
 		FcPatternGetString(match, FC_FILE, 0, (FcChar8 **) &file);
 		FcPatternGetInteger(match, FC_INDEX, 0, &index);
 
-		FcPatternDestroy (match);
-		FcPatternDestroy (pat);
 
 	font = ftglCreateExtrudeFont(file);
 	if (!font)
 		die("FTGL createFont", "");
+
+	FcPatternDestroy (match);
+	FcPatternDestroy (pat);
 
 	#ifdef	OPENGL
 		transX = transY = 0.0;


### PR DESCRIPTION
I hit this issue too on Linux (debian/testing). Moving the destroy call fixes it for me.
